### PR TITLE
removed pacakges - insecure and autopublish

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -16,8 +16,6 @@ typescript@4.5.4              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server@0.5.0            # Server-side component of the `meteor shell` command
 hot-module-replacement@0.5.2  # Update client in development without reloading the page
 
-autopublish@1.0.7             # Publish all data to the clients (for prototyping)
-insecure@1.0.7                # Allow all DB writes from clients (for prototyping)
 static-html@1.3.2             # Define static page content in .html files
 react-meteor-data       # React higher-order component for reactively tracking Meteor data
 juliancwirko:postcss

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,4 @@
 allow-deny@1.1.1
-autopublish@1.0.7
 autoupdate@1.8.0
 babel-compiler@7.9.2
 babel-runtime@1.5.1
@@ -30,7 +29,6 @@ hot-module-replacement@0.5.2
 html-tools@1.1.3
 htmljs@1.1.1
 id-map@1.1.1
-insecure@1.0.7
 inter-process-messaging@0.1.1
 juliancwirko:postcss@2.1.0
 launch-screen@1.3.0


### PR DESCRIPTION
**Removing the insecure package**

Every newly created Meteor project has the insecure package installed by default. This package allows us to edit the database from the client as we said above, which is useful for quick prototyping.

We need to remove it, because as the name suggests it is insecure.

`meteor remove insecure`

Now our app changes don’t work anymore as we have revoked all client-side database permissions. If we try to insert a new contact for example, we are going to see `insert failed: Access denied in our browser console`.

Removing the autopublish package

Just like with insecure package, all new Meteor apps start with the autopublish package, which automatically synchronizes all the database contents to the client. So we should remove it:

`meteor remove autopublish`

When the app refreshes, the contacts list will be empty. Without the autopublish package, we will have to specify explicitly what the server sends to the client. The functions in Meteor that do this are `Meteor.publish` and `Meteor.subscribe`.